### PR TITLE
add CLI script, clean up readme, more useful printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,36 +26,43 @@ We recommand to run more shots to obtain more desirable prompts.
 - ftfy >= 6.1.1
 - mediapy >= 1.1.2
 
-## Usage
-```python
-import open_clip
-from optim_utils import * 
-import argparse
-from PIL import Image
+## Setup
 
-# load the target image
-image = Image.open(image_path)
+Ensure you have python 3 installed.
 
-# load args
-args = argparse.Namespace()
-args.__dict__.update(read_json("sample_config.json"))
-
-# load CLIP model
-device = "cuda" if torch.cuda.is_available() else "cpu"
-model, _, preprocess = open_clip.create_model_and_transforms(args.clip_model, pretrained=args.clip_pretrain, device=device)
-
-# You may modify the hyperparamters
-args.prompt_len = 8 # number of tokens for the learned prompt
-
-# optimize prompt
-learned_prompt = optimize_prompt(model, preprocess, args, device, target_images=[image])
-print(learned_prompt)
+Create a virtual environment, activate it, and install dependencies:
+```sh
+$ python -m venv .venv
+$ source .venv/bin/activate
+$ pip install -r requirements.txt
 ```
 
-Note: \
-```prompt_len```: number of tokens in the optimized prompt \
-```batch_size```: number of target images/prompts been used for each iteraion \
-```prompt_bs```: number of intializations
+## Usage
 
-## Langugae Model Prompt Experiments
+A script is provided to perform prompt inversion (finding a prompt from an image or set of images). For examples of other usages, see [the examples folder](./examples).
+
+```sh
+python run.py image.png
+```
+
+You can pass multiple images to optimize a prompt across all images.
+
+## Parameters
+
+Config can be loaded from a JSON file. A sample config is provided at [./sample-config.json](sample_config.json).
+
+Config has the following parameters:
+
+- `prompt_len`: the number of tokens in the optimized prompt. 16 empirically results in the most generalizable performance. more is not necessarily better.
+- `iter`: the total number of iterations to run for.
+- `lr`: the learning weight for the [optimizer](https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html).
+- `weight_decay`: the weight decay for the optimizer.
+- `prompt_bs`: number of initializations.
+- `batch_size`: number of target images/prompts used for each iteration.
+- `clip_model`: the name of the CLiP model for use with . `"ViT-H-14"` is the model used in SD 2.0 and Midjourney. `"ViT-L-14"` is the model used in SD 1.5. This should ideally match your target generator.
+- `clip_pretrain`: the name of the pretrained model for [open_clip](https://github.com/mlfoundations/open_clip). For `"ViT-H-14"` use `"laion2b_s32b_b79k"`. For `"ViT-L-14"` use `"openai"`.
+- `print_step`: if not null, how often (in steps) to print a line giving current status.
+- `print_new_best`: whether to print out new best prompts whenver found. will be quite noisy initially.
+
+## Language Model Prompt Experiments
 You may check the code in `prompt_lm/` folder.

--- a/optim_utils.py
+++ b/optim_utils.py
@@ -138,6 +138,7 @@ def optimize_prompt_loop(model, tokenizer, token_embedding, all_target_features,
     weight_decay = args.weight_decay
     print_step = args.print_step
     batch_size = args.batch_size
+    print_new_best = getattr(args, 'print_new_best', False)
 
     # initialize prompt
     prompt_embeds, dummy_embeds, dummy_ids = initialize_prompt(tokenizer, token_embedding, args, device)
@@ -196,12 +197,18 @@ def optimize_prompt_loop(model, tokenizer, token_embedding, all_target_features,
 
         decoded_text = decode_ids(nn_indices, tokenizer)[best_indx]
         if print_step is not None and (step % print_step == 0 or step == opt_iters-1):
-            print(f"step: {step}, lr: {curr_lr}, cosim: {universal_cosim_score:.3f}, text: {decoded_text}")
-        
+            per_step_message = f"step: {step}, lr: {curr_lr}"
+            if not print_new_best:
+                per_step_message = f"\n{per_step_message}, cosim: {universal_cosim_score:.3f}, text: {decoded_text}"
+            print(per_step_message)
+
         if best_sim < universal_cosim_score:
             best_sim = universal_cosim_score
-            
             best_text = decoded_text
+            if print_new_best:
+                print(f"new best cosine sim: {best_sim}")
+                print(f"new best prompt: {best_text}")
+
 
     if print_step is not None:
         print()

--- a/run.py
+++ b/run.py
@@ -1,0 +1,40 @@
+import sys
+from PIL import Image
+
+if len(sys.argv) < 2:
+  sys.exit("""Usage: python run.py path-to-image [path-to-image-2 ...]
+Passing multiple images will optimize a single prompt across all passed images, useful for style transfer.
+""")
+
+config_path = "sample_config.json"
+
+image_paths = sys.argv[1:]
+
+# load the target image
+images = [Image.open(image_path) for image_path in image_paths]
+
+# defer loading other stuff until we confirm the images loaded
+import argparse
+import open_clip
+from optim_utils import *
+
+print("Initializing...")
+
+# load args
+args = argparse.Namespace()
+args.__dict__.update(read_json(config_path))
+
+# You may modify the hyperparamters here
+# args.print_new_best = True
+
+# load CLIP model
+device = "cuda" if torch.cuda.is_available() else "cpu"
+model, _, preprocess = open_clip.create_model_and_transforms(args.clip_model, pretrained=args.clip_pretrain, device=device)
+
+print(f"Running for {args.iter} steps.")
+if getattr(args, 'print_new_best', False) and args.print_step is not None:
+  print(f"Intermediate results will be printed every {args.print_step} steps.")
+
+# optimize prompt
+learned_prompt = optimize_prompt(model, preprocess, args, device, target_images=images)
+print(learned_prompt)

--- a/run.py
+++ b/run.py
@@ -25,7 +25,7 @@ args = argparse.Namespace()
 args.__dict__.update(read_json(config_path))
 
 # You may modify the hyperparamters here
-# args.print_new_best = True
+args.print_new_best = True
 
 # load CLIP model
 device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/sample_config.json
+++ b/sample_config.json
@@ -1,5 +1,5 @@
 {
-    "prompt_len": 8,
+    "prompt_len": 16,
     "iter": 3000,
     "lr": 0.1,
     "weight_decay": 0.1,


### PR DESCRIPTION
I've made a couple of tweaks which will hopefully make it easier for people to get started with this project:

I moved the usage example from the readme into its own file and made it read the path to the image or images from the CLI arguments, so it can be run directly without having to know Python.

I've tried to document usage a little bit more, including all of the parameters. I'm not sure what `prompt_bs` and `batch_size` do from their descriptions, so I left the descriptions from the existing readme. Can you explain those in more detail?

I changed the default prompt length from 8 to 16 tokens, since the paper says that 16 was the most generalizable.

Lastly, I tweaked the script so it will (optionally) print whenever it finds a new best candidate, instead of printing whichever candidate it is looking at every 100 steps. That's more useful, I think. It still prints a message every 100 steps so you can see how close it's getting to finishing.